### PR TITLE
Configure FastMCP server to listen on port 8009

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ Use the MCP development server to test changes:
 # Test the FastMCP implementation
 mcp dev things_fast_server.py
 
+# The FastMCP server listens on http://0.0.0.0:8009
+
 # Or test the traditional implementation
 mcp dev things_server.py
 ```

--- a/src/things_mcp/fast_server.py
+++ b/src/things_mcp/fast_server.py
@@ -31,9 +31,11 @@ logger = get_logger(__name__)
 
 # Create the FastMCP server
 mcp = FastMCP(
-    "Things", 
+    "Things",
     description="Interact with the Things task management app",
-    version="0.1.1"
+    version="0.1.1",
+    host="0.0.0.0",
+    port=8009,
 )
 
 # LIST VIEWS
@@ -630,8 +632,8 @@ def run_things_mcp_server():
     else:
         logger.info("Things app is running and ready for operations")
         
-    # Run the MCP server
-    mcp.run()
+    # Run the MCP server with HTTP transport
+    mcp.run(transport="streamable-http")
 
 if __name__ == "__main__":
     run_things_mcp_server()


### PR DESCRIPTION
## Summary
- configure `FastMCP` to listen on `0.0.0.0:8009`
- run fast server via Streamable HTTP transport
- document the server address in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b39a737808330981f778f253e1300