### PR TITLE
Add logging for constructed Things URLs

### DIFF
--- a/src/things_mcp/simple_url_scheme.py
+++ b/src/things_mcp/simple_url_scheme.py
@@ -99,7 +99,8 @@ def construct_url(command: str, params: Dict[str, Any]) -> str:
             encoded_params.append(f"{key}={encoded_value}")
         
         url += "?" + "&".join(encoded_params)
-    
+
+    logger.debug(f"Constructed Things URL: {url}")
     return url
 
 # URL scheme functions based on Things documentation

--- a/src/things_mcp/url_scheme.py
+++ b/src/things_mcp/url_scheme.py
@@ -199,7 +199,8 @@ def construct_url(command: str, params: Dict[str, Any]) -> str:
             encoded_params.append(f"{key}={encoded_value}")
         
         url += "?" + "&".join(encoded_params)
-    
+
+    logger.debug(f"Constructed Things URL: {url}")
     return url
 
 


### PR DESCRIPTION
## Summary
- log the final URL in url_scheme and simple_url_scheme before returning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b400543cc833086aa9f88d0f49469