### PR TITLE
Remove CLI script and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,12 @@ This server unlocks the power of AI or automated workflows for your task managem
 
 ## Quick start
 
-1. Install from PyPI:
+1. Clone this repository and install it in editable mode using [uv](https://github.com/astral-sh/uv).
+   If you don't have `uv` installed yet, run `pipx install uv` (or `pip install uv`).
    ```bash
-   pip install things3-enhanced-mcp
+   git clone https://github.com/excelsier/things-fastmcp.git
+   cd things-fastmcp
+   uv pip install -e .
    ```
 2. Configure your Things authentication token:
    ```bash
@@ -38,13 +41,18 @@ This server unlocks the power of AI or automated workflows for your task managem
    ```
 3. Run the server:
    ```bash
-   things3-enhanced-mcp
+   python things_fast_server.py
    ```
    The FastMCP server listens on `http://0.0.0.0:8009`.
+   Alternatively, use:
+   ```bash
+   mcp dev things_fast_server.py
+   ```
+   The `mcp dev` command uses the [MCP development helper](https://github.com/anthropics/mcp-cli#development-helper) for auto-reload during development.
 
 ## Development
 
-Use the MCP development helper to run the server from source:
+Use `mcp dev` from the [MCP development helper](https://github.com/anthropics/mcp-cli#development-helper) to run the server from source:
 
 ```bash
 mcp dev things_fast_server.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,6 @@ dependencies = [
     "things-py>=0.0.15",
 ]
 
-[project.scripts]
-things3-enhanced-mcp = "src.things_mcp.fast_server:run_things_mcp_server"
-
 [project.urls]
 "Homepage" = "https://github.com/excelsier/things-fastmcp"
 "Bug Tracker" = "https://github.com/excelsier/things-fastmcp/issues"

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -38,8 +38,6 @@ registry:
   installation:
     type: "pip"
     package: "things3-enhanced-mcp"
-    command: "things3-enhanced-mcp"
-    
   # Configuration requirements
   configuration:
     required:


### PR DESCRIPTION
## Summary
- drop `things3-enhanced-mcp` console script
- clean up smithery install block
- show how to install from source in README
- document using `mcp dev` helper
- mention `uv` package manager

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b4d61d6808330bd74b564215784db