### PR TITLE
Improve shutdown handling

### DIFF
--- a/src/things_mcp/shutdown.py
+++ b/src/things_mcp/shutdown.py
@@ -1,0 +1,22 @@
+"""Gracefully handle shutdown signals."""
+import asyncio
+import os
+import signal
+import logging
+
+
+def setup_interrupt_handler(logger: logging.Logger | None = None) -> None:
+    """Register SIGINT and SIGTERM handlers that stop the event loop and exit."""
+    if logger is None:
+        logger = logging.getLogger(__name__)
+
+    def _shutdown(signum: int, frame) -> None:  # pragma: no cover - signal handler
+        logger.info("Received interrupt signal, shutting down")
+        try:
+            loop = asyncio.get_event_loop()
+            loop.stop()
+        finally:
+            os._exit(0)
+
+    signal.signal(signal.SIGINT, _shutdown)
+    signal.signal(signal.SIGTERM, _shutdown)

--- a/src/things_mcp/things_server.py
+++ b/src/things_mcp/things_server.py
@@ -13,11 +13,15 @@ import mcp.server.stdio
 from mcp_tools import get_mcp_tools_list
 from handlers import handle_tool_call
 from utils import validate_tool_registration, app_state
+from .shutdown import setup_interrupt_handler
 import url_scheme
 
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
+
+# Exit immediately on Ctrl+C even if connections remain
+setup_interrupt_handler(logger)
 
 server = Server("things")
 
@@ -103,4 +107,8 @@ async def main():
         )
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        logger.info("Server stopped by user")
+        sys.exit(0)

--- a/things_fast_server.py
+++ b/things_fast_server.py
@@ -6,6 +6,7 @@ This version uses the modern FastMCP pattern for better maintainability.
 import logging
 import sys
 from src.things_mcp.fast_server import run_things_mcp_server
+from src.things_mcp.shutdown import setup_interrupt_handler
 
 # Configure logging
 logging.basicConfig(
@@ -13,6 +14,9 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
+
+# Exit immediately on Ctrl+C even if connections remain
+setup_interrupt_handler(logger)
 
 if __name__ == "__main__":
     logger.info("Starting Things FastMCP Server")

--- a/things_server.py
+++ b/things_server.py
@@ -1,3 +1,7 @@
+"""Legacy Things MCP server (deprecated).
+
+This script is kept for compatibility only and is no longer maintained.
+"""
 from typing import Any, List, Optional, Dict
 import logging
 import asyncio


### PR DESCRIPTION
## Summary
- extract interrupt handler to `src/things_mcp/shutdown.py`
- use the helper in `things_fast_server.py` and `src/things_mcp/things_server.py`
- mark `things_server.py` as deprecated and revert signal handling

## Testing
- `ruff check things_fast_server.py src/things_mcp/things_server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b4f8ddd308330b91de69a4a73c225