### PR TITLE
Fix sensitive token leak

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -70,7 +70,7 @@ Created comprehensive test scripts:
 ## Configuration Details
 
 ### Authentication Token
-- Token: `2H2TYfJbSfWaEYntMJkreg` (configured for testing)
+- Token: `<your-token>` (configured for testing)
 - Location: `~/.things-mcp/config.json`
 - Environment variable: `THINGS_AUTH_TOKEN`
 


### PR DESCRIPTION
## Summary
- replace the example token string in `IMPLEMENTATION_SUMMARY.md` with a placeholder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ca6cdb96883309fd6a2a71ca124d3