### PR TITLE
Fix changelog link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,4 +42,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Attribution
 Based on the original [things-mcp](https://github.com/hald/things-mcp) by Harald Lindstrøm
 
-[1.0.0]: https://github.com/excelsier/things-fastmcp/releases/tag/v1.0.0 
+[1.0.0]: https://github.com/CaseyRo/things-fastmcp/releases/tag/v1.0.0 


### PR DESCRIPTION
## Summary
- update the URL in the changelog footnote

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ca6ba3c608330977e3dba9340deb7