### PR TITLE
Fix repo links in smithery config

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -30,9 +30,9 @@ registry:
     platform: ["local"]
     
   # Documentation
-  homepage: "https://github.com/excelsier/things-fastmcp"
-  repository: "https://github.com/excelsier/things-fastmcp"
-  documentation: "https://github.com/excelsier/things-fastmcp#readme"
+  homepage: "https://github.com/CaseyRo/things-fastmcp"
+  repository: "https://github.com/CaseyRo/things-fastmcp"
+  documentation: "https://github.com/CaseyRo/things-fastmcp#readme"
   
   # Installation
   installation:


### PR DESCRIPTION
## Summary
- update `smithery.yaml` to use the new GitHub repo URL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ca6b2a9fc833099e216c0a78a86d6