### PR TITLE
Fix FastMCP initialization

### DIFF
--- a/src/things_mcp/fast_server.py
+++ b/src/things_mcp/fast_server.py
@@ -33,8 +33,6 @@ logger = get_logger(__name__)
 # Create the FastMCP server
 mcp = FastMCP(
     "Things",
-    description="Interact with the Things task management app",
-    version="0.1.1",
     host="0.0.0.0",
     port=8009,
 )

--- a/src/things_mcp/simple_server.py
+++ b/src/things_mcp/simple_server.py
@@ -29,9 +29,7 @@ logger = logging.getLogger(__name__)
 
 # Create the FastMCP server
 mcp = FastMCP(
-    "Things", 
-    description="Interact with the Things task management app",
-    version="0.2.0"
+    "Things",
 )
 
 # Simple retry decorator


### PR DESCRIPTION
## Summary
- ensure compatibility with older FastMCP versions by removing unsupported `version` argument

## Testing
- `python -m compileall -q src`


------
https://chatgpt.com/codex/tasks/task_e_688cab2800e0833099a8e1e13e191410