### PR TITLE
Add run script and rich logging for Things FastMCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS
+
+This file tracks the agent's thoughts, ideas, and work flow for the `things-fastmcp` repository.
+
+## Instructions
+- Append a new entry under `## Log` for each change made.
+- Briefly describe the reasoning behind significant decisions.
+- Run `ruff check .` and `pytest` after modifications.
+
+## Log
+### 2025-09-01
+- Added `run_things_fastmcp.sh` helper script and integrated Rich logging.
+- Documented macOS limitations preventing Docker usage for opening scripts.
+- Introduced this AGENTS.md to record ongoing work.

--- a/README.md
+++ b/README.md
@@ -41,14 +41,18 @@ This server unlocks the power of AI or automated workflows for your task managem
    ```
 3. Run the server:
    ```bash
-   python things_fast_server.py
+   ./run_things_fastmcp.sh
    ```
-   The FastMCP server listens on `http://0.0.0.0:8009`.
+   The FastMCP server listens on `http://0.0.0.0:8009` and uses [Rich](https://github.com/Textualize/rich) for colorful terminal output.
    Alternatively, use:
    ```bash
    mcp dev things_fast_server.py
    ```
    The `mcp dev` command uses the [MCP development helper](https://github.com/anthropics/mcp-cli#development-helper) for auto-reload during development.
+
+### Why not Docker?
+
+The server interacts with the native Things application through AppleScript and the `open` command. Docker containers on macOS run inside a lightweight VM and don't have access to these host-level scripting capabilities. As a result the MCP server must run directly on macOS rather than inside a Docker container.
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "httpx>=0.28.1",
     "mcp[cli]>=1.2.0",
     "things-py>=0.0.15",
+    "rich>=13.7.0",
 ]
 
 [project.urls]

--- a/run_things_fastmcp.sh
+++ b/run_things_fastmcp.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Simple helper to run the Things FastMCP server.
+# Uses the current Python environment.
+set -e
+python "$(dirname "$0")/things_fast_server.py"

--- a/things_fast_server.py
+++ b/things_fast_server.py
@@ -5,15 +5,20 @@ This version uses the modern FastMCP pattern for better maintainability.
 """
 import logging
 import sys
+from rich.console import Console
+from rich.logging import RichHandler
 from src.things_mcp.fast_server import run_things_mcp_server
 from src.things_mcp.shutdown import setup_interrupt_handler
 
-# Configure logging
+# Configure rich logging
+console = Console()
 logging.basicConfig(
     level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    format="%(message)s",
+    datefmt="[%X]",
+    handlers=[RichHandler(console=console, rich_tracebacks=True)]
 )
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("things_fast_server")
 
 # Exit immediately on Ctrl+C even if connections remain
 setup_interrupt_handler(logger)
@@ -25,6 +30,6 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         logger.info("Server stopped by user")
         sys.exit(0)
-    except Exception as e:
-        logger.error(f"Error running server: {str(e)}")
+    except Exception:
+        logger.exception("Error running server")
         sys.exit(1)


### PR DESCRIPTION
## Summary
- add helper script to launch Things FastMCP server
- document macOS Docker limitations and reference new script
- enhance server logging with Rich and add Rich dependency
- add AGENTS.md to record workflow and required checks

## Testing
- `ruff check .` *(fails: many existing style errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5734761a883309ab3a090b29cdac4