### PR TITLE
Add privacy and terms documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,7 @@ This file tracks the agent's thoughts, ideas, and work flow for the `things-fast
 ### 2025-09-01
 - Updated run script to bootstrap a uv-managed virtual environment or fall back to system Python.
 - Clarified Quick Start docs about the helper script's environment handling.
+
+### 2025-10-07
+- Added standalone privacy and terms documents so operators understand local data handling and policy expectations.
+- Updated README to link to the new policies and prompt users to review them before setup, keeping onboarding aligned with compliance guidance.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,40 @@
+# Privacy Notice
+
+_Last updated: 2025-10-07_
+
+The Things FastMCP server is designed to run entirely on your macOS device. It never sends your task data to the maintainers or to any third-party service beyond the Model Context Protocol (MCP) client you authorize. This notice explains what information the server accesses, how it is stored, and how you can remove it.
+
+## Data the server can access
+
+When you start the server you grant it permission to interact with the local Things 3 application via AppleScript and the official URL scheme. Depending on the tools you invoke, the server may read or modify the following information that already lives in your Things app:
+
+- Task, project, checklist, and area titles, notes, tags, deadlines, and completion status
+- Metadata such as creation dates, reminders, and linked items exposed by the Things API
+- Task identifiers that Things uses to reference individual records
+
+The server also requires a Things authentication token so that URL commands can be executed. You provide this token explicitly via the `configure_token.py` helper or the `THINGS_AUTH_TOKEN` environment variable.
+
+## Local storage and logging
+
+All persistent data is stored locally on the same macOS account that runs the server:
+
+- The authentication token and runtime settings are written to `~/.things-mcp/config.json` when you run `configure_token.py` or when the configuration module saves updates.
+- The server writes runtime information, warnings, and errors to the terminal. If you redirect logs to a file, the contents remain on your machine.
+- Optional debugging artifacts such as the dead-letter queue (`things_dlq.json`) or cache snapshots are created in the project directory when the related features are enabled.
+
+No telemetry, analytics, or remote logging is performed by default. Network traffic initiated by the server is limited to the MCP protocol messages exchanged with the client that you launch (for example, Claude Desktop) and to any integrations you explicitly configure.
+
+## Data retention and deletion
+
+Because all storage is local, you control retention. To remove sensitive data you can:
+
+1. Delete `~/.things-mcp/config.json` to clear the saved Things authentication token and reset configuration values. The file will be recreated with defaults the next time the server starts.
+2. Delete `things_dlq.json`, cache files, or any other artifacts you created during debugging.
+3. Uninstall the repository directory to remove the code and any local virtual environments.
+4. Revoke the Things authentication token inside the Things macOS app if you believe it has been exposed.
+
+Restart the server after deleting configuration files so that it regenerates clean defaults. If you are unsure which files to delete, search for items created at the time you ran the server and remove them manually.
+
+## Questions and contact
+
+This project is community-maintained. Report privacy issues or questions by opening a GitHub issue in the repository. Do not include personal or task data in public issue descriptions—sanitize examples before sharing them.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Things 3 Enhanced MCP
 
-This repository provides a Model Context Protocol (MCP) server for [Things](https://culturedcode.com/things/). It exposes a set of tools that allow AI assistants or automation platforms—for example Claude Desktop or n8n—to read and modify your tasks, projects and areas via the Things URL scheme.
+This repository provides a Model Context Protocol (MCP) server for [Things](https://culturedcode.com/things/).
+
+> **Important:** Review the [Privacy Notice](PRIVACY.md) and [Terms of Use](TERMS_OF_USE.md) before running or deploying the server.
+
+It exposes a set of tools that allow AI assistants or automation platforms—for example Claude Desktop or n8n—to read and modify your tasks, projects and areas via the Things URL scheme.
 
 The codebase contains a modern implementation using the **FastMCP** pattern. It offers improved reliability features such as caching, rate limiting and an AppleScript fallback. A legacy `things_server.py` still exists for compatibility but will be removed by the end of the year.
 
@@ -27,6 +31,8 @@ This server unlocks the power of AI or automated workflows for your task managem
 - Rich set of tools for listing, searching and modifying Things items (see `src/things_mcp/fast_server.py` for decorators)
 
 ## Quick start
+
+Before installing dependencies or launching the server, confirm you have read the [Privacy Notice](PRIVACY.md) and [Terms of Use](TERMS_OF_USE.md).
 
 1. Clone this repository and install it in editable mode using [uv](https://github.com/astral-sh/uv).
    If you don't have `uv` installed yet, run `pipx install uv` (or `pip install uv`).

--- a/TERMS_OF_USE.md
+++ b/TERMS_OF_USE.md
@@ -1,0 +1,31 @@
+# Terms of Use
+
+_Last updated: 2025-10-07_
+
+These Terms of Use govern your access to and use of the Things FastMCP project (the "Software"). By running the Software you agree to the responsibilities and limitations described below. If you do not agree, do not install or execute the Software.
+
+## Your responsibilities
+
+- **Authorized access only**. Use the Software solely with Things accounts and macOS devices that you own or are authorized to manage.
+- **Protect credentials**. Safeguard the Things authentication token stored in `~/.things-mcp/config.json` or any environment variables you configure. Rotate or revoke the token if you suspect it has been exposed.
+- **Review data access**. Understand that the Software can read and modify tasks, projects, and other personal information stored in Things. Ensure that anyone with access to your machine is aware of this capability.
+- **Provide clear prompts**. When using AI assistants with this MCP server, avoid prompting them to violate platform rules, perform unauthorized scraping, or process sensitive personal data beyond what is necessary for your workflow.
+
+## Limitations and disclaimers
+
+- **No warranties**. The Software is provided "as is" without warranties of any kind. Use it at your own risk.
+- **Local-only operation**. The maintainers do not operate any hosted service. You are responsible for securing the machine on which the Software runs, including backups and system updates.
+- **Data integrity**. Automated edits to Things data may be irreversible. Review generated changes before confirming them inside your MCP client.
+- **Third-party policies**. Your use of Things, macOS, or any AI assistant remains subject to their respective license agreements and policies.
+
+## Compliance with OpenAI policies
+
+If you connect the Software to an OpenAI-powered assistant (for example, via OpenAI’s MCP tooling), you must follow OpenAI’s [Usage Policies](https://openai.com/policies/usage-policies) and [Terms of Use](https://openai.com/policies/terms-of-use). Do not use the Software to build experiences that violate those documents, including prohibited content categories or privacy requirements.
+
+## Updates to these terms
+
+The maintainers may update these Terms of Use by committing changes to this repository. Material updates will be noted in the project changelog or README. Continued use of the Software after updates constitutes acceptance of the revised terms.
+
+## Contact
+
+Report security or policy concerns by opening an issue in the repository. Provide only the minimum information necessary to describe the problem and avoid sharing personal task data.


### PR DESCRIPTION
## Summary
- add standalone PRIVACY.md describing local data handling and deletion steps
- document responsibilities and policy references in a new TERMS_OF_USE.md
- update README to link to the new policies and prompt users to review them before setup

## Testing
- `ruff check .` *(fails: pre-existing lint errors in legacy files)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e4d2736aac8330a26d804889ed99a6