### PR TITLE
Add FastMCP metadata guidance for clients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,6 @@ This file tracks the agent's thoughts, ideas, and work flow for the `things-fast
 ### 2025-10-07
 - Added FastMCP metadata (instructions, website, icon) constants and wired them into the server instantiation.
 - Documented the surfaced assistant guidance in the README to mirror the MCP experience.
+
+### 2025-10-07
+- Converted MCP icon metadata to use `mcp.types.Icon` objects to satisfy FastMCP validation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,7 @@ This file tracks the agent's thoughts, ideas, and work flow for the `things-fast
 ### 2025-09-01
 - Updated run script to bootstrap a uv-managed virtual environment or fall back to system Python.
 - Clarified Quick Start docs about the helper script's environment handling.
+
+### 2025-10-07
+- Added FastMCP metadata (instructions, website, icon) constants and wired them into the server instantiation.
+- Documented the surfaced assistant guidance in the README to mirror the MCP experience.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This server unlocks the power of AI or automated workflows for your task managem
 - FastMCP based server entry point [`things_fast_server.py`](things_fast_server.py) that calls `run_things_mcp_server()` from the library
 - Legacy standard MCP implementation in [`things_server.py`](things_server.py) for compatibility
 - Rich set of tools for listing, searching and modifying Things items (see `src/things_mcp/fast_server.py` for decorators)
+- Curated FastMCP metadata so assistants see capabilities, limitations, and support links out of the box
 
 ## Quick start
 
@@ -54,6 +55,16 @@ This server unlocks the power of AI or automated workflows for your task managem
 ### Why not Docker?
 
 The server interacts with the native Things application through AppleScript and the `open` command. Docker containers on macOS run inside a lightweight VM and don't have access to these host-level scripting capabilities. As a result the MCP server must run directly on macOS rather than inside a Docker container.
+
+### Assistant guidance surfaced to clients
+
+When a Model Context Protocol client connects, it now receives:
+
+- **Instructions** outlining the major Things 3 tools that are available, common limitations (macOS requirements, attachment access), and a reminder to review sensitive output.
+- **Website metadata** that points to this repository for documentation and updates.
+- **Iconography** (using an OpenMoji notepad) so the integration is easy to recognize in clients such as ChatGPT or Claude Desktop.
+
+These metadata fields help align what users read in the README with what assistants display in their UI.
 
 ## Development
 

--- a/src/things_mcp/fast_server.py
+++ b/src/things_mcp/fast_server.py
@@ -50,9 +50,12 @@ INSTRUCTIONS_TEXT = (
 
 WEBSITE_URL = "https://github.com/CaseyRo/things-fastmcp"
 
-ICON_URLS = {
-    "64": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/72x72/1F4DD.png",
-}
+ICONS: List[types.Icon] = [
+    types.Icon(
+        src="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/72x72/1F4DD.png",
+        sizes=["64x64"],
+    ),
+]
 
 # Create the FastMCP server
 mcp = FastMCP(
@@ -61,7 +64,7 @@ mcp = FastMCP(
     port=8009,
     instructions=INSTRUCTIONS_TEXT,
     website_url=WEBSITE_URL,
-    icons=ICON_URLS,
+    icons=ICONS,
 )
 
 # LIST VIEWS

--- a/src/things_mcp/fast_server.py
+++ b/src/things_mcp/fast_server.py
@@ -30,11 +30,38 @@ from .tag_handler import ensure_tags_exist
 setup_logging(console_level="INFO", file_level="DEBUG", structured_logs=True)
 logger = get_logger(__name__)
 
+
+INSTRUCTIONS_TEXT = (
+    "### Things MCP server guidance\n\n"
+    "Use these tools to review and maintain your Things 3 workspace on macOS."
+    "\n\n"
+    "**Capabilities**\n"
+    "- List inbox, Today, Upcoming, Someday, Anytime, and Logbook items\n"
+    "- Inspect and update projects, areas, tags, and todos via the Things URL scheme\n"
+    "- Launch advanced Things automations with pre-built URL actions\n\n"
+    "**Limitations**\n"
+    "- Requires Things 3 for macOS with scripting permissions enabled\n"
+    "- Only accesses data stored locally in Things; attachments remain unavailable\n"
+    "- Some operations depend on the Things URL scheme and may take a few seconds\n\n"
+    "**Support & Contact**\n"
+    "- Review outputs before sharing because personal data may be present\n"
+    "- Report issues or request features at https://github.com/CaseyRo/things-fastmcp/issues\n"
+)
+
+WEBSITE_URL = "https://github.com/CaseyRo/things-fastmcp"
+
+ICON_URLS = {
+    "64": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/72x72/1F4DD.png",
+}
+
 # Create the FastMCP server
 mcp = FastMCP(
     "Things",
     host="0.0.0.0",
     port=8009,
+    instructions=INSTRUCTIONS_TEXT,
+    website_url=WEBSITE_URL,
+    icons=ICON_URLS,
 )
 
 # LIST VIEWS


### PR DESCRIPTION
## Summary
- add curated instruction, website, and icon metadata constants for the FastMCP server
- document the surfaced assistant guidance in the README so user-facing text matches the MCP metadata
- log the metadata update in AGENTS.md for repository history

## Testing
- ruff check . *(fails: existing lint errors in legacy files)*
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e4d73ae11c8330bf7274108331be06