### PR TITLE
Remove duplicate FastMCP binding announcements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,12 @@ This file tracks the agent's thoughts, ideas, and work flow for the `things-fast
 ### 2025-09-01
 - Updated run script to bootstrap a uv-managed virtual environment or fall back to system Python.
 - Clarified Quick Start docs about the helper script's environment handling.
+
+### 2025-09-02
+- Switched FastMCP server default bind address to localhost with env override and documented exposure steps.
+
+### 2025-10-07
+- Clarified binding logs and helper exports so launchers surface localhost default without double logging.
+
+### 2025-10-07
+- Removed duplicate binding announcements from the CLI entrypoint so runtime logging only happens once and cached the binding helper for reuse.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Things 3 Enhanced MCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Default the FastMCP server binding to `127.0.0.1` with an opt-in `THINGS_FASTMCP_HOST` override for remote exposure.
+
 ## [1.0.0] - 2025-05-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This server unlocks the power of AI or automated workflows for your task managem
    ```bash
    ./run_things_fastmcp.sh
    ```
-   The FastMCP server listens on `http://0.0.0.0:8009` and uses [Rich](https://github.com/Textualize/rich) for colorful terminal output.
+   The FastMCP server listens on `http://127.0.0.1:8009` by default and uses [Rich](https://github.com/Textualize/rich) for colorful terminal output. To expose it beyond the local machine, export `THINGS_FASTMCP_HOST=0.0.0.0` before launching.
    Alternatively, use:
    ```bash
    mcp dev things_fast_server.py

--- a/run_things_fastmcp.sh
+++ b/run_things_fastmcp.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Run the Things FastMCP server.
 #
+# By default the server listens on 127.0.0.1. To expose it beyond the local
+# machine export `THINGS_FASTMCP_HOST=0.0.0.0` (or another interface) before
+# launching.
+#
 # If [uv](https://github.com/astral-sh/uv) is installed, this script uses it to
 # create (or reuse) a virtual environment and install dependencies. Otherwise
 # it falls back to the first available python3/python executable.

--- a/src/things_mcp/fast_server.py
+++ b/src/things_mcp/fast_server.py
@@ -4,8 +4,10 @@ Things MCP Server implementation using the FastMCP pattern.
 This provides a more modern and maintainable approach to the Things integration.
 """
 import logging
+import os
 import asyncio
 import traceback
+from functools import lru_cache
 from typing import Dict, Any, Optional, List, Union
 import things
 
@@ -30,10 +32,25 @@ from .tag_handler import ensure_tags_exist
 setup_logging(console_level="INFO", file_level="DEBUG", structured_logs=True)
 logger = get_logger(__name__)
 
+# Network binding configuration
+HOST_ENV_VAR = "THINGS_FASTMCP_HOST"
+DEFAULT_HOST = "127.0.0.1"
+
+
+@lru_cache(maxsize=1)
+def get_binding_host() -> str:
+    """Return the host for the FastMCP server, honoring the override env var."""
+    value = os.getenv(HOST_ENV_VAR)
+    if value is None:
+        return DEFAULT_HOST
+
+    value = value.strip()
+    return value or DEFAULT_HOST
+
 # Create the FastMCP server
 mcp = FastMCP(
     "Things",
-    host="0.0.0.0",
+    host=get_binding_host(),
     port=8009,
 )
 
@@ -645,6 +662,20 @@ def get_cache_statistics() -> str:
 # Main entry point
 def run_things_mcp_server():
     """Run the Things MCP server"""
+    host = get_binding_host()
+    if host == DEFAULT_HOST:
+        logger.info(
+            "FastMCP will bind to %s (set %s=0.0.0.0 to allow remote connections)",
+            DEFAULT_HOST,
+            HOST_ENV_VAR,
+        )
+    else:
+        logger.info(
+            "FastMCP binding override detected: %s=%s",
+            HOST_ENV_VAR,
+            host,
+        )
+
     # Check if Things app is available
     if not app_state.update_app_state():
         logger.warning("Things app is not running at startup. MCP will attempt to launch it when needed.")


### PR DESCRIPTION
## Summary
- deduplicate FastMCP binding logging by relying on the runtime announcement inside `run_things_mcp_server`
- cache the binding host helper for reuse when instantiating the FastMCP server
- record the October 7, 2025 follow-up work in the operational AGENTS log

## Testing
- ruff check . *(fails: existing lint violations in untouched modules)*
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4d73c70ac8330ba235e6897f8f211