### PR TITLE
Handle missing Icon class in FastMCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ This file tracks the agent's thoughts, ideas, and work flow for the `things-fast
 - Run `ruff check .` and `pytest` after modifications.
 
 ## Log
+### 2025-10-09
+- Added compatibility helper so FastMCP icon metadata works whether or not `mcp.types.Icon` is available in the runtime.
+
 ### 2025-10-07
 - Implemented logging redaction across handlers and the AppleScript bridge so user task content stays out of logs.
 - Removed duplicate binding announcements from the CLI entrypoint so runtime logging only happens once and cached the binding helper for reuse.

--- a/src/things_mcp/fast_server.py
+++ b/src/things_mcp/fast_server.py
@@ -52,8 +52,29 @@ INSTRUCTIONS_TEXT = (
 
 WEBSITE_URL = "https://github.com/CaseyRo/things-fastmcp"
 
-ICONS: List[types.Icon] = [
-    types.Icon(
+# Type alias supporting both newer FastMCP installs (with mcp.types.Icon)
+# and older releases that still expect simple dictionaries for icon metadata.
+IconLike = Union[Any, Dict[str, Any]]
+
+
+def _build_icon(src: str, *, sizes: Optional[List[str]] = None, mime_type: Optional[str] = None) -> IconLike:
+    """Create an icon instance compatible with the available MCP types module."""
+    icon_cls = getattr(types, "Icon", None)
+    if icon_cls is not None:
+        return icon_cls(src=src, sizes=sizes, mimeType=mime_type)
+
+    # Fall back to a plain dictionary for environments running an older MCP build
+    # that predates the Icon model.
+    icon_data: Dict[str, Any] = {"src": src}
+    if sizes:
+        icon_data["sizes"] = sizes
+    if mime_type:
+        icon_data["mimeType"] = mime_type
+    return icon_data
+
+
+ICONS: List[IconLike] = [
+    _build_icon(
         src="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/72x72/1F4DD.png",
         sizes=["64x64"],
     ),


### PR DESCRIPTION
## Summary
- build FastMCP icon metadata through a helper that falls back to plain dicts when `mcp.types.Icon` is unavailable
- record the compatibility change in the agent log

## Testing
- ruff check . *(fails: existing unused imports and other pre-existing lint errors)*
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e7c5b2d3c083309517e8d843c42502