### PR TITLE
Handle FastMCP website_url compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ This file tracks the agent's thoughts, ideas, and work flow for the `things-fast
 ## Log
 ### 2025-10-09
 - Added compatibility helper so FastMCP icon metadata works whether or not `mcp.types.Icon` is available in the runtime.
+- Guarded FastMCP server construction so `website_url` metadata is only passed when supported by the installed MCP version.
 
 ### 2025-10-07
 - Implemented logging redaction across handlers and the AppleScript bridge so user task content stays out of logs.

--- a/src/things_mcp/fast_server.py
+++ b/src/things_mcp/fast_server.py
@@ -9,6 +9,7 @@ import asyncio
 import traceback
 from functools import lru_cache
 from typing import Dict, Any, Optional, List, Union
+import inspect
 import things
 
 from mcp.server.fastmcp import FastMCP
@@ -94,15 +95,32 @@ def get_binding_host() -> str:
     value = value.strip()
     return value or DEFAULT_HOST
 
+# Determine supported FastMCP constructor arguments at import time so the
+# server remains compatible with runtimes that predate the `website_url`
+# parameter.
+_fastmcp_init_params = inspect.signature(FastMCP.__init__).parameters
+
+_FASTMCP_SUPPORTS_WEBSITE_URL = "website_url" in _fastmcp_init_params
+
+
+def _create_fastmcp_instance() -> FastMCP:
+    kwargs: Dict[str, Any] = {
+        "host": get_binding_host(),
+        "port": 8009,
+        "instructions": INSTRUCTIONS_TEXT,
+        "icons": ICONS,
+    }
+
+    if _FASTMCP_SUPPORTS_WEBSITE_URL:
+        kwargs["website_url"] = WEBSITE_URL
+    else:
+        logger.debug("FastMCP runtime does not support website_url; skipping metadata field")
+
+    return FastMCP("Things", **kwargs)
+
+
 # Create the FastMCP server
-mcp = FastMCP(
-    "Things",
-    host=get_binding_host(),
-    port=8009,
-    instructions=INSTRUCTIONS_TEXT,
-    website_url=WEBSITE_URL,
-    icons=ICONS,
-)
+mcp = _create_fastmcp_instance()
 
 # LIST VIEWS
 


### PR DESCRIPTION
## Summary
- detect FastMCP constructor support for the website_url parameter at import time
- skip passing website_url when unsupported to keep the server compatible with older MCP releases

## Testing
- ruff check . *(fails: pre-existing lint errors in unrelated modules)*
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e7c6f7219c8330903d9a648d640860