### PR TITLE
Handle FastMCP runtimes without icon support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ This file tracks the agent's thoughts, ideas, and work flow for the `things-fast
 - Run `ruff check .` and `pytest` after modifications.
 
 ## Log
+### 2025-10-10
+- Added FastMCP constructor introspection for icon support and guarded icon metadata so older runtimes still launch cleanly.
+
 ### 2025-10-09
 - Added compatibility helper so FastMCP icon metadata works whether or not `mcp.types.Icon` is available in the runtime.
 - Guarded FastMCP server construction so `website_url` metadata is only passed when supported by the installed MCP version.

--- a/src/things_mcp/fast_server.py
+++ b/src/things_mcp/fast_server.py
@@ -96,11 +96,12 @@ def get_binding_host() -> str:
     return value or DEFAULT_HOST
 
 # Determine supported FastMCP constructor arguments at import time so the
-# server remains compatible with runtimes that predate the `website_url`
-# parameter.
+# server remains compatible with runtimes that predate newer metadata
+# parameters like `website_url` and `icons`.
 _fastmcp_init_params = inspect.signature(FastMCP.__init__).parameters
 
 _FASTMCP_SUPPORTS_WEBSITE_URL = "website_url" in _fastmcp_init_params
+_FASTMCP_SUPPORTS_ICONS = "icons" in _fastmcp_init_params
 
 
 def _create_fastmcp_instance() -> FastMCP:
@@ -108,13 +109,17 @@ def _create_fastmcp_instance() -> FastMCP:
         "host": get_binding_host(),
         "port": 8009,
         "instructions": INSTRUCTIONS_TEXT,
-        "icons": ICONS,
     }
 
     if _FASTMCP_SUPPORTS_WEBSITE_URL:
         kwargs["website_url"] = WEBSITE_URL
     else:
         logger.debug("FastMCP runtime does not support website_url; skipping metadata field")
+
+    if _FASTMCP_SUPPORTS_ICONS:
+        kwargs["icons"] = ICONS
+    else:
+        logger.debug("FastMCP runtime does not support icons; skipping metadata field")
 
     return FastMCP("Things", **kwargs)
 


### PR DESCRIPTION
## Summary
- extend FastMCP constructor introspection to detect icon support alongside website URL support
- only pass icon metadata when the runtime accepts it and log when omitted
- document the compatibility tweak in the agent log

## Testing
- ruff check . *(fails: pre-existing lint warnings in unrelated files)*
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e81a51409883308c64476761ae693d