### PR TITLE
Add host and port override options for FastMCP helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ This file tracks the agent's thoughts, ideas, and work flow for the `things-fast
 - Run `ruff check .` and `pytest` after modifications.
 
 ## Log
+### 2025-10-11
+- Added CLI flags and env var validation to the run script so operators can easily bind to alternate hosts and ports without manual exports.
+- Extended FastMCP server binding logic and README guidance to document the new port override support.
 ### 2025-10-10
 - Added FastMCP constructor introspection for icon support and guarded icon metadata so older runtimes still launch cleanly.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Before installing dependencies or launching the server, confirm you have read th
    ```bash
    ./run_things_fastmcp.sh
    ```
-   The FastMCP server listens on `http://127.0.0.1:8009` by default and uses [Rich](https://github.com/Textualize/rich) for colorful terminal output. To expose it beyond the local machine, export `THINGS_FASTMCP_HOST=0.0.0.0` before launching.
+   The FastMCP server listens on `http://127.0.0.1:8009` by default and uses [Rich](https://github.com/Textualize/rich) for colorful terminal output. To expose it beyond the local machine, either export `THINGS_FASTMCP_HOST=0.0.0.0` or run `./run_things_fastmcp.sh --host 0.0.0.0`. You can also change the port by setting `THINGS_FASTMCP_PORT=9000` (for example) or passing `--port 9000` to the helper script.
    Alternatively, use:
    ```bash
    mcp dev things_fast_server.py

--- a/run_things_fastmcp.sh
+++ b/run_things_fastmcp.sh
@@ -1,14 +1,78 @@
 #!/usr/bin/env bash
 # Run the Things FastMCP server.
 #
-# By default the server listens on 127.0.0.1. To expose it beyond the local
-# machine export `THINGS_FASTMCP_HOST=0.0.0.0` (or another interface) before
-# launching.
+# By default the server listens on 127.0.0.1:8009. To expose it beyond the local
+# machine export `THINGS_FASTMCP_HOST=0.0.0.0` (or another interface) or pass
+# `--host 0.0.0.0`. To run on a different port export `THINGS_FASTMCP_PORT` or
+# use `--port 9000` (for example).
 #
 # If [uv](https://github.com/astral-sh/uv) is installed, this script uses it to
 # create (or reuse) a virtual environment and install dependencies. Otherwise
 # it falls back to the first available python3/python executable.
 set -euo pipefail
+
+HOST_OVERRIDE="${THINGS_FASTMCP_HOST:-}"
+PORT_OVERRIDE="${THINGS_FASTMCP_PORT:-}"
+
+print_usage() {
+  cat <<'USAGE'
+Usage: run_things_fastmcp.sh [--host HOST] [--port PORT] [--] [PYTHON_ARGS...]
+
+Options:
+  --host HOST    Bind the FastMCP server to the specified interface.
+                 (Defaults to 127.0.0.1. Use 0.0.0.0 to listen on all interfaces.)
+  --port PORT    Serve the FastMCP server on the specified TCP port (default 8009).
+  -h, --help     Show this help text and exit.
+
+Any additional arguments after `--` are forwarded to the Python entrypoint.
+Environment variables THINGS_FASTMCP_HOST and THINGS_FASTMCP_PORT override the
+defaults and are updated when using the corresponding flags.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --host requires a value" >&2
+        exit 1
+      fi
+      HOST_OVERRIDE="$2"
+      shift 2
+      ;;
+    --port)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --port requires a value" >&2
+        exit 1
+      fi
+      PORT_OVERRIDE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ -n "$PORT_OVERRIDE" ]]; then
+  if [[ ! "$PORT_OVERRIDE" =~ ^[0-9]+$ ]]; then
+    echo "Error: THINGS_FASTMCP_PORT/--port must be an integer" >&2
+    exit 1
+  fi
+  export THINGS_FASTMCP_PORT="$PORT_OVERRIDE"
+fi
+
+if [[ -n "$HOST_OVERRIDE" ]]; then
+  export THINGS_FASTMCP_HOST="$HOST_OVERRIDE"
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/src/things_mcp/fast_server.py
+++ b/src/things_mcp/fast_server.py
@@ -82,7 +82,9 @@ ICONS: List[IconLike] = [
 ]
 # Network binding configuration
 HOST_ENV_VAR = "THINGS_FASTMCP_HOST"
+PORT_ENV_VAR = "THINGS_FASTMCP_PORT"
 DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8009
 
 
 @lru_cache(maxsize=1)
@@ -94,6 +96,38 @@ def get_binding_host() -> str:
 
     value = value.strip()
     return value or DEFAULT_HOST
+
+
+@lru_cache(maxsize=1)
+def get_binding_port() -> int:
+    """Return the port for the FastMCP server, honoring the override env var."""
+    value = os.getenv(PORT_ENV_VAR)
+    if value is None or not value.strip():
+        return DEFAULT_PORT
+
+    stripped = value.strip()
+
+    try:
+        port = int(stripped)
+    except ValueError:
+        logger.warning(
+            "Invalid %s value '%s'; falling back to default port %s",
+            PORT_ENV_VAR,
+            value,
+            DEFAULT_PORT,
+        )
+        return DEFAULT_PORT
+
+    if not 0 < port < 65536:
+        logger.warning(
+            "%s value %s out of valid TCP port range; using default %s",
+            PORT_ENV_VAR,
+            port,
+            DEFAULT_PORT,
+        )
+        return DEFAULT_PORT
+
+    return port
 
 # Determine supported FastMCP constructor arguments at import time so the
 # server remains compatible with runtimes that predate newer metadata
@@ -107,7 +141,7 @@ _FASTMCP_SUPPORTS_ICONS = "icons" in _fastmcp_init_params
 def _create_fastmcp_instance() -> FastMCP:
     kwargs: Dict[str, Any] = {
         "host": get_binding_host(),
-        "port": 8009,
+        "port": get_binding_port(),
         "instructions": INSTRUCTIONS_TEXT,
     }
 


### PR DESCRIPTION
## Summary
- add host and port override flags to `run_things_fastmcp.sh` and validate inputs before launch
- allow the FastMCP server to honor a `THINGS_FASTMCP_PORT` environment variable when binding
- document the new exposure options in the README and note the update in `AGENTS.md`

## Testing
- `ruff check .` *(fails: existing unused import errors in legacy modules)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e81e6f26508330b01355c68f3258ee