### PR TITLE
Add MCP tool annotations across servers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@ This file tracks the agent's thoughts, ideas, and work flow for the `things-fast
 
 ## Log
 ### 2025-10-11
+- Added MCP tool annotations across registration and Fast/Simple server implementations to align with MCP metadata expectations.
+
+### 2025-10-11
 - Added CLI flags and env var validation to the run script so operators can easily bind to alternate hosts and ports without manual exports.
 - Extended FastMCP server binding logic and README guidance to document the new port override support.
 ### 2025-10-10

--- a/src/things_mcp/fast_server.py
+++ b/src/things_mcp/fast_server.py
@@ -29,6 +29,52 @@ from .logging_config import setup_logging, get_logger, log_operation_start, log_
 from .cache import cached, invalidate_caches_for, get_cache_stats, CACHE_TTL
 from .tag_handler import ensure_tags_exist
 
+
+READ_ONLY_ANNOTATIONS = types.ToolAnnotations(
+    readOnlyHint=True,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+
+ADD_ANNOTATIONS = types.ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=False,
+)
+
+UPDATE_ANNOTATIONS = types.ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+
+TOOL_ANNOTATIONS: Dict[str, types.ToolAnnotations] = {
+    "get-inbox": READ_ONLY_ANNOTATIONS,
+    "get-today": READ_ONLY_ANNOTATIONS,
+    "get-upcoming": READ_ONLY_ANNOTATIONS,
+    "get-anytime": READ_ONLY_ANNOTATIONS,
+    "get-someday": READ_ONLY_ANNOTATIONS,
+    "get-logbook": READ_ONLY_ANNOTATIONS,
+    "get-trash": READ_ONLY_ANNOTATIONS,
+    "get-todos": READ_ONLY_ANNOTATIONS,
+    "get-projects": READ_ONLY_ANNOTATIONS,
+    "get-areas": READ_ONLY_ANNOTATIONS,
+    "get-tags": READ_ONLY_ANNOTATIONS,
+    "get-tagged-items": READ_ONLY_ANNOTATIONS,
+    "search-todos": READ_ONLY_ANNOTATIONS,
+    "search-advanced": READ_ONLY_ANNOTATIONS,
+    "add-todo": ADD_ANNOTATIONS,
+    "add-project": ADD_ANNOTATIONS,
+    "update-todo": UPDATE_ANNOTATIONS,
+    "update-project": UPDATE_ANNOTATIONS,
+    "show-item": READ_ONLY_ANNOTATIONS,
+    "search-items": READ_ONLY_ANNOTATIONS,
+    "get-recent": READ_ONLY_ANNOTATIONS,
+    "get-cache-stats": READ_ONLY_ANNOTATIONS,
+}
+
 # Configure enhanced logging
 setup_logging(console_level="INFO", file_level="DEBUG", structured_logs=True)
 logger = get_logger(__name__)
@@ -163,7 +209,7 @@ mcp = _create_fastmcp_instance()
 
 # LIST VIEWS
 
-@mcp.tool(name="get-inbox")
+@mcp.tool(name="get-inbox", annotations=TOOL_ANNOTATIONS["get-inbox"])
 def get_inbox() -> str:
     """Get todos from Inbox"""
     import time
@@ -184,7 +230,7 @@ def get_inbox() -> str:
         log_operation_end("get-inbox", False, time.time() - start_time, error=str(e))
         raise
 
-@mcp.tool(name="get-today")
+@mcp.tool(name="get-today", annotations=TOOL_ANNOTATIONS["get-today"])
 @cached(ttl=CACHE_TTL.get("today", 30))
 def get_today() -> str:
     """Get todos due today"""
@@ -206,7 +252,7 @@ def get_today() -> str:
         log_operation_end("get-today", False, time.time() - start_time, error=str(e))
         raise
 
-@mcp.tool(name="get-upcoming")
+@mcp.tool(name="get-upcoming", annotations=TOOL_ANNOTATIONS["get-upcoming"])
 def get_upcoming() -> str:
     """Get upcoming todos"""
     todos = things.upcoming()
@@ -217,7 +263,7 @@ def get_upcoming() -> str:
     formatted_todos = [format_todo(todo) for todo in todos]
     return "\n\n---\n\n".join(formatted_todos)
 
-@mcp.tool(name="get-anytime")
+@mcp.tool(name="get-anytime", annotations=TOOL_ANNOTATIONS["get-anytime"])
 def get_anytime() -> str:
     """Get todos from Anytime list"""
     todos = things.anytime()
@@ -228,7 +274,7 @@ def get_anytime() -> str:
     formatted_todos = [format_todo(todo) for todo in todos]
     return "\n\n---\n\n".join(formatted_todos)
 
-@mcp.tool(name="get-someday")
+@mcp.tool(name="get-someday", annotations=TOOL_ANNOTATIONS["get-someday"])
 def get_someday() -> str:
     """Get todos from Someday list"""
     todos = things.someday()
@@ -239,7 +285,7 @@ def get_someday() -> str:
     formatted_todos = [format_todo(todo) for todo in todos]
     return "\n\n---\n\n".join(formatted_todos)
 
-@mcp.tool(name="get-logbook")
+@mcp.tool(name="get-logbook", annotations=TOOL_ANNOTATIONS["get-logbook"])
 def get_logbook(period: str = "7d", limit: int = 50) -> str:
     """
     Get completed todos from Logbook, defaults to last 7 days
@@ -259,7 +305,7 @@ def get_logbook(period: str = "7d", limit: int = 50) -> str:
     formatted_todos = [format_todo(todo) for todo in todos]
     return "\n\n---\n\n".join(formatted_todos)
 
-@mcp.tool(name="get-trash")
+@mcp.tool(name="get-trash", annotations=TOOL_ANNOTATIONS["get-trash"])
 def get_trash() -> str:
     """Get trashed todos"""
     todos = things.trash()
@@ -272,7 +318,7 @@ def get_trash() -> str:
 
 # BASIC TODO OPERATIONS
 
-@mcp.tool(name="get-todos")
+@mcp.tool(name="get-todos", annotations=TOOL_ANNOTATIONS["get-todos"])
 def get_todos(project_uuid: Optional[str] = None, include_items: bool = True) -> str:
     """
     Get todos from Things, optionally filtered by project
@@ -294,7 +340,7 @@ def get_todos(project_uuid: Optional[str] = None, include_items: bool = True) ->
     formatted_todos = [format_todo(todo) for todo in todos]
     return "\n\n---\n\n".join(formatted_todos)
 
-@mcp.tool(name="get-projects")
+@mcp.tool(name="get-projects", annotations=TOOL_ANNOTATIONS["get-projects"])
 def get_projects(include_items: bool = False) -> str:
     """
     Get all projects from Things
@@ -310,7 +356,7 @@ def get_projects(include_items: bool = False) -> str:
     formatted_projects = [format_project(project, include_items) for project in projects]
     return "\n\n---\n\n".join(formatted_projects)
 
-@mcp.tool(name="get-areas")
+@mcp.tool(name="get-areas", annotations=TOOL_ANNOTATIONS["get-areas"])
 def get_areas(include_items: bool = False) -> str:
     """
     Get all areas from Things
@@ -328,7 +374,7 @@ def get_areas(include_items: bool = False) -> str:
 
 # TAG OPERATIONS
 
-@mcp.tool(name="get-tags")
+@mcp.tool(name="get-tags", annotations=TOOL_ANNOTATIONS["get-tags"])
 def get_tags(include_items: bool = False) -> str:
     """
     Get all tags
@@ -344,7 +390,7 @@ def get_tags(include_items: bool = False) -> str:
     formatted_tags = [format_tag(tag, include_items) for tag in tags]
     return "\n\n---\n\n".join(formatted_tags)
 
-@mcp.tool(name="get-tagged-items")
+@mcp.tool(name="get-tagged-items", annotations=TOOL_ANNOTATIONS["get-tagged-items"])
 def get_tagged_items(tag: str) -> str:
     """
     Get items with a specific tag
@@ -362,7 +408,7 @@ def get_tagged_items(tag: str) -> str:
 
 # SEARCH OPERATIONS
 
-@mcp.tool(name="search-todos")
+@mcp.tool(name="search-todos", annotations=TOOL_ANNOTATIONS["search-todos"])
 def search_todos(query: str) -> str:
     """
     Search todos by title or notes
@@ -378,7 +424,7 @@ def search_todos(query: str) -> str:
     formatted_todos = [format_todo(todo) for todo in todos]
     return "\n\n---\n\n".join(formatted_todos)
 
-@mcp.tool(name="search-advanced")
+@mcp.tool(name="search-advanced", annotations=TOOL_ANNOTATIONS["search-advanced"])
 def search_advanced(
     status: Optional[str] = None,
     start_date: Optional[str] = None,
@@ -429,7 +475,7 @@ def search_advanced(
 
 # MODIFICATION OPERATIONS
 
-@mcp.tool(name="add-todo")
+@mcp.tool(name="add-todo", annotations=TOOL_ANNOTATIONS["add-todo"])
 def add_task(
     title: str,
     notes: Optional[str] = None,
@@ -494,7 +540,7 @@ def add_task(
         logger.error(f"Error creating todo: {str(e)}")
         return f"Error creating todo: {str(e)}"
 
-@mcp.tool(name="add-project")
+@mcp.tool(name="add-project", annotations=TOOL_ANNOTATIONS["add-project"])
 def add_new_project(
     title: str,
     notes: Optional[str] = None,
@@ -549,7 +595,7 @@ def add_new_project(
         logger.error(f"Error creating project: {str(e)}")
         return f"Error creating project: {str(e)}"
 
-@mcp.tool(name="update-todo")
+@mcp.tool(name="update-todo", annotations=TOOL_ANNOTATIONS["update-todo"])
 def update_task(
     id: str,
     title: Optional[str] = None,
@@ -608,7 +654,7 @@ def update_task(
         logger.error(f"Error updating todo: {str(e)}")
         return f"Error updating todo: {str(e)}"
 
-@mcp.tool(name="update-project")
+@mcp.tool(name="update-project", annotations=TOOL_ANNOTATIONS["update-project"])
 def update_existing_project(
     id: str,
     title: Optional[str] = None,
@@ -663,7 +709,7 @@ def update_existing_project(
         logger.error(f"Error updating project: {str(e)}")
         return f"Error updating project: {str(e)}"
 
-@mcp.tool(name="show-item")
+@mcp.tool(name="show-item", annotations=TOOL_ANNOTATIONS["show-item"])
 def show_item(
     id: str,
     query: Optional[str] = None,
@@ -698,7 +744,7 @@ def show_item(
         logger.error(f"Error showing item: {str(e)}")
         return f"Error showing item: {str(e)}"
 
-@mcp.tool(name="search-items")
+@mcp.tool(name="search-items", annotations=TOOL_ANNOTATIONS["search-items"])
 def search_all_items(query: str) -> str:
     """
     Search for items in Things
@@ -723,7 +769,7 @@ def search_all_items(query: str) -> str:
         logger.error(f"Error searching: {str(e)}")
         return f"Error searching: {str(e)}"
 
-@mcp.tool(name="get-recent")
+@mcp.tool(name="get-recent", annotations=TOOL_ANNOTATIONS["get-recent"])
 def get_recent(period: str) -> str:
     """
     Get recently created items
@@ -754,7 +800,7 @@ def get_recent(period: str) -> str:
         logger.error(f"Error getting recent items: {str(e)}")
         return f"Error getting recent items: {str(e)}"
 
-@mcp.tool(name="get-cache-stats")
+@mcp.tool(name="get-cache-stats", annotations=TOOL_ANNOTATIONS["get-cache-stats"])
 def get_cache_statistics() -> str:
     """Get cache performance statistics"""
     stats = get_cache_stats()

--- a/src/things_mcp/mcp_tools.py
+++ b/src/things_mcp/mcp_tools.py
@@ -4,7 +4,53 @@ MCP tools configuration for Things integration with Windsurf.
 This ensures proper tool registration and naming for seamless integration.
 """
 import mcp.types as types
-from typing import List
+from typing import List, Dict
+
+
+READ_ONLY_ANNOTATIONS = types.ToolAnnotations(
+    readOnlyHint=True,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+
+ADD_ANNOTATIONS = types.ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=False,
+)
+
+UPDATE_ANNOTATIONS = types.ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+
+
+ANNOTATIONS_MAP: Dict[str, types.ToolAnnotations] = {
+    "get-todos": READ_ONLY_ANNOTATIONS,
+    "get-projects": READ_ONLY_ANNOTATIONS,
+    "get-areas": READ_ONLY_ANNOTATIONS,
+    "get-inbox": READ_ONLY_ANNOTATIONS,
+    "get-today": READ_ONLY_ANNOTATIONS,
+    "get-upcoming": READ_ONLY_ANNOTATIONS,
+    "get-anytime": READ_ONLY_ANNOTATIONS,
+    "get-someday": READ_ONLY_ANNOTATIONS,
+    "get-logbook": READ_ONLY_ANNOTATIONS,
+    "get-trash": READ_ONLY_ANNOTATIONS,
+    "get-tags": READ_ONLY_ANNOTATIONS,
+    "get-tagged-items": READ_ONLY_ANNOTATIONS,
+    "search-todos": READ_ONLY_ANNOTATIONS,
+    "search-advanced": READ_ONLY_ANNOTATIONS,
+    "search-items": READ_ONLY_ANNOTATIONS,
+    "show-item": READ_ONLY_ANNOTATIONS,
+    "get-recent": READ_ONLY_ANNOTATIONS,
+    "add-todo": ADD_ANNOTATIONS,
+    "add-project": ADD_ANNOTATIONS,
+    "update-todo": UPDATE_ANNOTATIONS,
+    "update-project": UPDATE_ANNOTATIONS,
+}
 
 def get_mcp_tools_list() -> List[types.Tool]:
     """
@@ -17,6 +63,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="get-todos",
             description="Get todos from Things, optionally filtered by project",
+            annotations=ANNOTATIONS_MAP["get-todos"],
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -36,6 +83,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="get-projects",
             description="Get all projects from Things",
+            annotations=ANNOTATIONS_MAP["get-projects"],
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -51,6 +99,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="get-areas",
             description="Get all areas from Things",
+            annotations=ANNOTATIONS_MAP["get-areas"],
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -68,6 +117,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="get-inbox",
             description="Get todos from Inbox",
+            annotations=ANNOTATIONS_MAP["get-inbox"],
             inputSchema={
                 "type": "object",
                 "properties": {},
@@ -77,6 +127,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="get-today",
             description="Get todos due today",
+            annotations=ANNOTATIONS_MAP["get-today"],
             inputSchema={
                 "type": "object",
                 "properties": {},
@@ -86,6 +137,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="get-upcoming",
             description="Get upcoming todos",
+            annotations=ANNOTATIONS_MAP["get-upcoming"],
             inputSchema={
                 "type": "object",
                 "properties": {},
@@ -95,6 +147,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="get-anytime",
             description="Get todos from Anytime list",
+            annotations=ANNOTATIONS_MAP["get-anytime"],
             inputSchema={
                 "type": "object",
                 "properties": {},
@@ -104,6 +157,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="get-someday",
             description="Get todos from Someday list",
+            annotations=ANNOTATIONS_MAP["get-someday"],
             inputSchema={
                 "type": "object",
                 "properties": {},
@@ -113,6 +167,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="get-logbook",
             description="Get completed todos from Logbook, defaults to last 7 days",
+            annotations=ANNOTATIONS_MAP["get-logbook"],
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -134,6 +189,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="get-trash",
             description="Get trashed todos",
+            annotations=ANNOTATIONS_MAP["get-trash"],
             inputSchema={
                 "type": "object",
                 "properties": {},
@@ -145,6 +201,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="get-tags",
             description="Get all tags",
+            annotations=ANNOTATIONS_MAP["get-tags"],
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -160,6 +217,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="get-tagged-items",
             description="Get items with a specific tag",
+            annotations=ANNOTATIONS_MAP["get-tagged-items"],
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -176,6 +234,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="search-todos",
             description="Search todos by title or notes",
+            annotations=ANNOTATIONS_MAP["search-todos"],
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -190,6 +249,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="search-advanced",
             description="Advanced todo search with multiple filters",
+            annotations=ANNOTATIONS_MAP["search-advanced"],
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -228,6 +288,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="get-recent",
             description="Get recently created items",
+            annotations=ANNOTATIONS_MAP["get-recent"],
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -245,6 +306,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="add-todo",
             description="Create a new todo in Things",
+            annotations=ANNOTATIONS_MAP["add-todo"],
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -294,6 +356,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="add-project",
             description="Create a new project in Things",
+            annotations=ANNOTATIONS_MAP["add-project"],
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -339,6 +402,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="update-todo",
             description="Update an existing todo in Things",
+            annotations=ANNOTATIONS_MAP["update-todo"],
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -383,6 +447,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="update-project",
             description="Update an existing project in Things",
+            annotations=ANNOTATIONS_MAP["update-project"],
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -427,6 +492,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="search-items",
             description="Search for items in Things",
+            annotations=ANNOTATIONS_MAP["search-items"],
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -442,6 +508,7 @@ def get_mcp_tools_list() -> List[types.Tool]:
         types.Tool(
             name="show-item",
             description="Show a specific item or list in Things",
+            annotations=ANNOTATIONS_MAP["show-item"],
             inputSchema={
                 "type": "object",
                 "properties": {

--- a/src/things_mcp/simple_server.py
+++ b/src/things_mcp/simple_server.py
@@ -20,6 +20,61 @@ from .simple_url_scheme import add_todo, add_project, update_todo, update_projec
 from .config import get_things_auth_token
 from .tag_handler import ensure_tags_exist
 
+
+READ_ONLY_ANNOTATIONS = types.ToolAnnotations(
+    readOnlyHint=True,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+
+ADD_ANNOTATIONS = types.ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=False,
+)
+
+UPDATE_ANNOTATIONS = types.ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+
+DELETE_ANNOTATIONS = types.ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=True,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+
+
+TOOL_ANNOTATIONS: Dict[str, types.ToolAnnotations] = {
+    "get-inbox": READ_ONLY_ANNOTATIONS,
+    "get-today": READ_ONLY_ANNOTATIONS,
+    "get-upcoming": READ_ONLY_ANNOTATIONS,
+    "get-anytime": READ_ONLY_ANNOTATIONS,
+    "get-someday": READ_ONLY_ANNOTATIONS,
+    "get-logbook": READ_ONLY_ANNOTATIONS,
+    "get-trash": READ_ONLY_ANNOTATIONS,
+    "get-todos": READ_ONLY_ANNOTATIONS,
+    "get-projects": READ_ONLY_ANNOTATIONS,
+    "get-areas": READ_ONLY_ANNOTATIONS,
+    "get-tags": READ_ONLY_ANNOTATIONS,
+    "get-tagged-items": READ_ONLY_ANNOTATIONS,
+    "search-todos": READ_ONLY_ANNOTATIONS,
+    "search-advanced": READ_ONLY_ANNOTATIONS,
+    "add-todo": ADD_ANNOTATIONS,
+    "add-project": ADD_ANNOTATIONS,
+    "update-todo": UPDATE_ANNOTATIONS,
+    "delete-todo": DELETE_ANNOTATIONS,
+    "update-project": UPDATE_ANNOTATIONS,
+    "delete-project": DELETE_ANNOTATIONS,
+    "show-item": READ_ONLY_ANNOTATIONS,
+    "search-items": READ_ONLY_ANNOTATIONS,
+    "get-recent": READ_ONLY_ANNOTATIONS,
+}
+
 # Simple logging setup
 logging.basicConfig(
     level=logging.INFO,
@@ -104,7 +159,7 @@ def ensure_things_running():
 
 # LIST VIEWS
 
-@mcp.tool(name="get-inbox")
+@mcp.tool(name="get-inbox", annotations=TOOL_ANNOTATIONS["get-inbox"])
 def get_inbox() -> str:
     """Get todos from Inbox"""
     # Check cache first
@@ -123,7 +178,7 @@ def get_inbox() -> str:
     cache.set("inbox", result)
     return result
 
-@mcp.tool(name="get-today")
+@mcp.tool(name="get-today", annotations=TOOL_ANNOTATIONS["get-today"])
 def get_today() -> str:
     """Get todos due today"""
     cached_result = cache.get("today", ttl_seconds=30)
@@ -141,7 +196,7 @@ def get_today() -> str:
     cache.set("today", result)
     return result
 
-@mcp.tool(name="get-upcoming")
+@mcp.tool(name="get-upcoming", annotations=TOOL_ANNOTATIONS["get-upcoming"])
 def get_upcoming() -> str:
     """Get upcoming todos"""
     cached_result = cache.get("upcoming", ttl_seconds=60)
@@ -159,7 +214,7 @@ def get_upcoming() -> str:
     cache.set("upcoming", result)
     return result
 
-@mcp.tool(name="get-anytime")
+@mcp.tool(name="get-anytime", annotations=TOOL_ANNOTATIONS["get-anytime"])
 def get_anytime() -> str:
     """Get todos from Anytime list"""
     cached_result = cache.get("anytime", ttl_seconds=300)
@@ -177,7 +232,7 @@ def get_anytime() -> str:
     cache.set("anytime", result)
     return result
 
-@mcp.tool(name="get-someday")
+@mcp.tool(name="get-someday", annotations=TOOL_ANNOTATIONS["get-someday"])
 def get_someday() -> str:
     """Get todos from Someday list"""
     cached_result = cache.get("someday", ttl_seconds=300)
@@ -195,7 +250,7 @@ def get_someday() -> str:
     cache.set("someday", result)
     return result
 
-@mcp.tool(name="get-logbook")
+@mcp.tool(name="get-logbook", annotations=TOOL_ANNOTATIONS["get-logbook"])
 def get_logbook(period: str = "7d", limit: int = 50) -> str:
     """Get completed todos from Logbook"""
     cache_key = f"logbook_{period}_{limit}"
@@ -216,7 +271,7 @@ def get_logbook(period: str = "7d", limit: int = 50) -> str:
     cache.set(cache_key, result)
     return result
 
-@mcp.tool(name="get-trash")
+@mcp.tool(name="get-trash", annotations=TOOL_ANNOTATIONS["get-trash"])
 def get_trash() -> str:
     """Get trashed todos"""
     todos = things.trash()
@@ -229,7 +284,7 @@ def get_trash() -> str:
 
 # BASIC TODO OPERATIONS
 
-@mcp.tool(name="get-todos")
+@mcp.tool(name="get-todos", annotations=TOOL_ANNOTATIONS["get-todos"])
 def get_todos(project_uuid: Optional[str] = None, include_items: bool = True) -> str:
     """Get todos, optionally filtered by project"""
     if project_uuid:
@@ -245,7 +300,7 @@ def get_todos(project_uuid: Optional[str] = None, include_items: bool = True) ->
     formatted_todos = [format_todo(todo) for todo in todos]
     return "\n\n---\n\n".join(formatted_todos)
 
-@mcp.tool(name="get-projects")
+@mcp.tool(name="get-projects", annotations=TOOL_ANNOTATIONS["get-projects"])
 def get_projects(include_items: bool = False) -> str:
     """Get all projects from Things"""
     cached_result = cache.get(f"projects_{include_items}", ttl_seconds=300)
@@ -263,7 +318,7 @@ def get_projects(include_items: bool = False) -> str:
     cache.set(f"projects_{include_items}", result)
     return result
 
-@mcp.tool(name="get-areas")
+@mcp.tool(name="get-areas", annotations=TOOL_ANNOTATIONS["get-areas"])
 def get_areas(include_items: bool = False) -> str:
     """Get all areas from Things"""
     cached_result = cache.get(f"areas_{include_items}", ttl_seconds=600)
@@ -283,7 +338,7 @@ def get_areas(include_items: bool = False) -> str:
 
 # TAG OPERATIONS
 
-@mcp.tool(name="get-tags")
+@mcp.tool(name="get-tags", annotations=TOOL_ANNOTATIONS["get-tags"])
 def get_tags(include_items: bool = False) -> str:
     """Get all tags"""
     cached_result = cache.get(f"tags_{include_items}", ttl_seconds=600)
@@ -301,7 +356,7 @@ def get_tags(include_items: bool = False) -> str:
     cache.set(f"tags_{include_items}", result)
     return result
 
-@mcp.tool(name="get-tagged-items")
+@mcp.tool(name="get-tagged-items", annotations=TOOL_ANNOTATIONS["get-tagged-items"])
 def get_tagged_items(tag: str) -> str:
     """Get items with a specific tag"""
     todos = things.todos(tag=tag)
@@ -314,7 +369,7 @@ def get_tagged_items(tag: str) -> str:
 
 # SEARCH OPERATIONS
 
-@mcp.tool(name="search-todos")
+@mcp.tool(name="search-todos", annotations=TOOL_ANNOTATIONS["search-todos"])
 def search_todos(query: str) -> str:
     """Search todos by title or notes"""
     todos = things.search(query)
@@ -325,7 +380,7 @@ def search_todos(query: str) -> str:
     formatted_todos = [format_todo(todo) for todo in todos]
     return "\n\n---\n\n".join(formatted_todos)
 
-@mcp.tool(name="search-advanced")
+@mcp.tool(name="search-advanced", annotations=TOOL_ANNOTATIONS["search-advanced"])
 def search_advanced(
     status: Optional[str] = None,
     start_date: Optional[str] = None,
@@ -362,7 +417,7 @@ def search_advanced(
 
 # MODIFICATION OPERATIONS
 
-@mcp.tool(name="add-todo")
+@mcp.tool(name="add-todo", annotations=TOOL_ANNOTATIONS["add-todo"])
 @retry(max_attempts=3)
 def add_task(
     title: str,
@@ -415,7 +470,7 @@ def add_task(
         logger.error(f"Error creating todo: {str(e)}")
         return f"❌ Error creating todo: {str(e)}"
 
-@mcp.tool(name="add-project")
+@mcp.tool(name="add-project", annotations=TOOL_ANNOTATIONS["add-project"])
 @retry(max_attempts=3)
 def add_new_project(
     title: str,
@@ -458,7 +513,7 @@ def add_new_project(
         logger.error(f"Error creating project: {str(e)}")
         return f"❌ Error creating project: {str(e)}"
 
-@mcp.tool(name="update-todo")
+@mcp.tool(name="update-todo", annotations=TOOL_ANNOTATIONS["update-todo"])
 @retry(max_attempts=3)
 def update_task(
     id: str,
@@ -502,7 +557,7 @@ def update_task(
         logger.error(f"Error updating todo: {str(e)}")
         return f"❌ Error updating todo: {str(e)}"
 
-@mcp.tool(name="delete-todo")
+@mcp.tool(name="delete-todo", annotations=TOOL_ANNOTATIONS["delete-todo"])
 @retry(max_attempts=3)
 def delete_todo(id: str) -> str:
     """Delete a todo by moving it to trash"""
@@ -525,7 +580,7 @@ def delete_todo(id: str) -> str:
         logger.error(f"Error deleting todo: {str(e)}")
         return f"❌ Error deleting todo: {str(e)}"
 
-@mcp.tool(name="update-project")
+@mcp.tool(name="update-project", annotations=TOOL_ANNOTATIONS["update-project"])
 @retry(max_attempts=3)
 def update_existing_project(
     id: str,
@@ -568,7 +623,7 @@ def update_existing_project(
         logger.error(f"Error updating project: {str(e)}")
         return f"❌ Error updating project: {str(e)}"
 
-@mcp.tool(name="delete-project")
+@mcp.tool(name="delete-project", annotations=TOOL_ANNOTATIONS["delete-project"])
 @retry(max_attempts=3)
 def delete_project(id: str) -> str:
     """Delete a project by moving it to trash"""
@@ -593,7 +648,7 @@ def delete_project(id: str) -> str:
         logger.error(f"Error deleting project: {str(e)}")
         return f"❌ Error deleting project: {str(e)}"
 
-@mcp.tool(name="show-item")
+@mcp.tool(name="show-item", annotations=TOOL_ANNOTATIONS["show-item"])
 def show_item(
     id: str,
     query: Optional[str] = None,
@@ -618,7 +673,7 @@ def show_item(
         logger.error(f"Error showing item: {str(e)}")
         return f"❌ Error showing item: {str(e)}"
 
-@mcp.tool(name="search-items")
+@mcp.tool(name="search-items", annotations=TOOL_ANNOTATIONS["search-items"])
 def search_all_items(query: str) -> str:
     """Search for items in Things"""
     if not ensure_things_running():
@@ -635,7 +690,7 @@ def search_all_items(query: str) -> str:
         logger.error(f"Error searching: {str(e)}")
         return f"❌ Error searching: {str(e)}"
 
-@mcp.tool(name="get-recent")
+@mcp.tool(name="get-recent", annotations=TOOL_ANNOTATIONS["get-recent"])
 def get_recent(period: str) -> str:
     """Get recently created items"""
     if not period or not any(period.endswith(unit) for unit in ['d', 'w', 'm', 'y']):


### PR DESCRIPTION
## Summary
- add MCP tool annotations to the registration list and both FastMCP server implementations
- ensure delete/update/add operations carry the correct metadata hints and log the change in AGENTS
- re-run validate_tool_registration to verify the updated metadata remains consistent

## Testing
- python - <<'PY'
import sys
sys.path.append('src')
from things_mcp.mcp_tools import get_mcp_tools_list
from things_mcp.utils import validate_tool_registration
result = validate_tool_registration(get_mcp_tools_list())
print(f"Tool registration valid: {result}")
PY
- ruff check .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68eab3326e588330b2f2253b8ac32953